### PR TITLE
Add note that this library requires python3.3 or newer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,12 @@ Deltas
 ======
 
 An open licensed (MIT) library for performing generating deltas (A.K.A sequences
- of operations) representing the difference between two sequences of comparable
+of operations) representing the difference between two sequences of comparable
 tokens.
 
 * **Installation:** **TODO**
-* **Repo**: `http://github.com/halfak/Deltas`_
+* **Repo**: `http://github.com/halfak/Deltas
+* Note this library requires Python 3.3 or newer
 
 This library is intended to be used to make experimental difference detection
 strategies more easily available.  There are currently two strategies available:


### PR DESCRIPTION
You found me out for running python 3.2. The "yield from" statement used in this library was introduced in Python 3.3 [1], which means the library will only run on that or newer right now. This pull request adds a note on this to the README file.

[1] https://docs.python.org/3/reference/expressions.html#yieldexpr
